### PR TITLE
Provide Microsoft.Extensions.ObjectPool

### DIFF
--- a/Dalamud.NET.Sdk/Sdk/Sdk.props
+++ b/Dalamud.NET.Sdk/Sdk/Sdk.props
@@ -59,6 +59,7 @@
     <Use_Dalamud_Lumina Condition="'$(Use_Dalamud_Lumina)' == ''">true</Use_Dalamud_Lumina>
     <Use_Dalamud_Lumina_Excel Condition="'$(Use_Dalamud_Lumina_Excel)' == ''">true</Use_Dalamud_Lumina_Excel>
     <Use_Dalamud_Serilog Condition="'$(Use_Dalamud_Serilog)' == ''">true</Use_Dalamud_Serilog>
+    <Use_Dalamud_MSObjectPool Condition="'$(Use_Dalamud_MSObjectPool)' == ''">true</Use_Dalamud_MSObjectPool>
   </PropertyGroup>
 
   <!-- Required NuGet packages -->
@@ -82,5 +83,6 @@
     <Reference Include="Lumina" Condition="'$(Use_Dalamud_Lumina)' == 'true'" Private="false" />
     <Reference Include="Lumina.Excel" Condition="'$(Use_Dalamud_Lumina_Excel)' == 'true'" Private="false" />
     <Reference Include="Serilog" Condition="'$(Use_Dalamud_Serilog)' == 'true'" Private="false" />
+    <Reference Include="Microsoft.Extensions.ObjectPool" Condition="'$(Use_Dalamud_MSObjectPool)' == 'true'" Private="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Would be nice if we could include this. It's used in [Lumina.Text.SeStringBuilder](https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Text/SeStringBuilder.cs#L36).
Maybe it should use `Use_Dalamud_Lumina`?